### PR TITLE
FIX: Deprecation Warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,8 +4,7 @@
   with_items: "{{ brew_taps }}"
 
 - name: Install the homebrew packages
-  homebrew: name={{ item }} state=latest
-  with_items: "{{ brew_packages }}"
+  homebrew: name={{ brew_packages }} state=latest
 
 - name: Install the cask packages
   homebrew_cask: name={{ item }}


### PR DESCRIPTION
[DEPRECATION WARNING]: Invoking "homebrew" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: "{{ item }}"`, please use `name: '{{ brew_packages }}'`
and remove the loop. This feature will be removed in version 2.11. Deprecation
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.